### PR TITLE
add optional password argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ chmod u+x setup.py
 
 ```
 
+- You can also use the optional `--password` argument to avoid manually typing your Linux password for every internal sudo command usage.
+
 ### Windows - How to use
 
-Download the latest [Python3](https://www.python.org/downloads/windows/).
-
-For now, it is highly recommended to use [Windows Subsystems for Linux (WSL)](https://docs.microsoft.com/en-gb/windows/wsl/install-win10) to use the build scripts. Hopefully I can make build scripts for Windows soon enough...
+- For now, Windows native build is not supported. Instead, you may use [Windows Subsystems for Linux (WSL)](https://docs.microsoft.com/en-gb/windows/wsl/install-win10) to use the build scripts.
 
 ## Features
 
@@ -43,8 +43,8 @@ For now, it is highly recommended to use [Windows Subsystems for Linux (WSL)](ht
       - Visualization disabled
    - OpenGL (:heavy_multiplication_x:)
    - GTest (:heavy_multiplication_x:)
-   - spdlog (:white_check_mark:)
-   - fast-cpp-csv-parser (:white_check_mark:)
+   - spdlog (:heavy_check_mark:)
+   - fast-cpp-csv-parser (:heavy_check_mark:)
 
 Status legend:
 :heavy_check_mark: - Fully supported, 

--- a/scripts/third_party_clone/ceres/install_ceres_solver.py
+++ b/scripts/third_party_clone/ceres/install_ceres_solver.py
@@ -3,12 +3,15 @@ import multiprocessing
 
 
 class install_ceres_solver:
-    def __init__(self, d, version_num):
+    def __init__(self, d, version_num, linux_password):
         self.d = d
         self.version_num = version_num
         self.install_dir = "./third_party/ceres-solver"
+        self.pw = linux_password
 
     def run(self):
+        self.pw.redeem()
+
         # Remove any pre-installed Ceres-solver
         os.system("sudo rm -rf ./third_party/ceres-solver")
 
@@ -42,6 +45,7 @@ class install_ceres_solver:
             return
 
         # Build
+        self.pw.redeem()
         num_cpu_cores = multiprocessing.cpu_count()
         os.system("make -j" + str(num_cpu_cores-1))
         os.system("make test")

--- a/scripts/third_party_clone/cpp_utils.py
+++ b/scripts/third_party_clone/cpp_utils.py
@@ -5,15 +5,18 @@ import time
 
 
 class install_cpp_utils:
-    def __init__(self, d):
+    def __init__(self, d, password):
         self.d = d
         self.install_dir = "./third_party"
+        self.pw = password
 
     def run(self):
         self.__install_csv_parser()
         self.__install_spdlog()
 
     def __install_spdlog(self):
+        self.pw.redeem()
+
         # https://github.com/gabime/spdlog.git
         path = self.install_dir + "/spdlog/spdlog"
         os.system("sudo rm -rf " + self.install_dir + "/spdlog")
@@ -33,6 +36,8 @@ class install_cpp_utils:
         os.chdir("../../../")
 
     def __install_csv_parser(self):
+        self.pw.redeem()
+        
         # https://github.com/ben-strasser/fast-cpp-csv-parser
         path = self.install_dir + "/fast-cpp-csv-parser"
         shutil.rmtree(path, ignore_errors=True)

--- a/scripts/third_party_clone/cpp_utils.py
+++ b/scripts/third_party_clone/cpp_utils.py
@@ -5,10 +5,10 @@ import time
 
 
 class install_cpp_utils:
-    def __init__(self, d, password):
+    def __init__(self, d, linux_password):
         self.d = d
         self.install_dir = "./third_party"
-        self.pw = password
+        self.pw = linux_password
 
     def run(self):
         self.__install_csv_parser()

--- a/scripts/third_party_clone/eigen/install_eigen.py
+++ b/scripts/third_party_clone/eigen/install_eigen.py
@@ -3,12 +3,15 @@ import multiprocessing
 
 
 class install_eigen:
-    def __init__(self, d, version_num):
+    def __init__(self, d, version_num, password):
         self.d = d
         self.version_num = version_num
         self.install_dir = "./third_party/Eigen"
+        self.pw = password
 
     def run(self):
+        self.pw.redeem()
+
         # Remove any pre-installed Eigen
         os.system("sudo rm -rf ./third_party/Eigen")
 
@@ -35,6 +38,7 @@ class install_eigen:
             return
 
         # Build
+        self.pw.redeem()
         num_cpu_cores = multiprocessing.cpu_count()
         os.system("make -j" + str(num_cpu_cores-1))
         os.system("sudo make install")

--- a/scripts/third_party_clone/eigen/install_eigen.py
+++ b/scripts/third_party_clone/eigen/install_eigen.py
@@ -3,11 +3,11 @@ import multiprocessing
 
 
 class install_eigen:
-    def __init__(self, d, version_num, password):
+    def __init__(self, d, version_num, linux_password):
         self.d = d
         self.version_num = version_num
         self.install_dir = "./third_party/Eigen"
-        self.pw = password
+        self.pw = linux_password
 
     def run(self):
         self.pw.redeem()

--- a/scripts/third_party_clone/gtsam/install_gtsam.py
+++ b/scripts/third_party_clone/gtsam/install_gtsam.py
@@ -3,12 +3,14 @@ import multiprocessing
 
 
 class install_gtsam:
-    def __init__(self, d, version_num):
+    def __init__(self, d, version_num, linux_password):
         self.d = d
         self.version_num = version_num
         self.install_dir = "./third_party/GTSAM"
+        self.pw = linux_password
 
     def run(self):
+        self.pw.redeem()
         # Remove any pre-installed GTSAM
         os.system("sudo rm -rf ./third_party/GTSAM")
 
@@ -39,6 +41,7 @@ class install_gtsam:
             return
 
         # Build
+        self.pw.redeem()
         num_cpu_cores = multiprocessing.cpu_count()
         os.system("make check -j" + str(num_cpu_cores-1))
         os.system("make -j" + str(num_cpu_cores-1))

--- a/scripts/third_party_clone/opencv/install_opencv.py
+++ b/scripts/third_party_clone/opencv/install_opencv.py
@@ -3,13 +3,16 @@ import multiprocessing
 
 
 class install_opencv:
-    def __init__(self, d, version_num, build_contrib):
+    def __init__(self, d, version_num, build_contrib, password):
         self.d = d
         self.version_num = version_num
         self.install_dir = "./third_party/opencv"
         self.build_contrib = build_contrib
+        self.pw = password
 
     def run(self):
+        self.pw.redeem()
+
         # Remove any pre-installed OpenCV
         os.system("sudo rm -rf ./third_party/opencv*")
 
@@ -47,6 +50,7 @@ class install_opencv:
             return
 
         # Build
+        self.pw.redeem()
         num_cpu_cores = multiprocessing.cpu_count()
         os.system("make -j" + str(num_cpu_cores-1))
         os.system("sudo make install")

--- a/scripts/third_party_clone/opencv/install_opencv.py
+++ b/scripts/third_party_clone/opencv/install_opencv.py
@@ -3,12 +3,12 @@ import multiprocessing
 
 
 class install_opencv:
-    def __init__(self, d, version_num, build_contrib, password):
+    def __init__(self, d, version_num, build_contrib, linux_password):
         self.d = d
         self.version_num = version_num
         self.install_dir = "./third_party/opencv"
         self.build_contrib = build_contrib
-        self.pw = password
+        self.pw = linux_password
 
     def run(self):
         self.pw.redeem()

--- a/scripts/third_party_clone/pcl/install_pcl.py
+++ b/scripts/third_party_clone/pcl/install_pcl.py
@@ -3,12 +3,15 @@ import multiprocessing
 
 
 class install_pcl:
-    def __init__(self, d, version_num):
+    def __init__(self, d, version_num, linux_password):
         self.d = d
         self.version_num = version_num
         self.install_dir = "./third_party/pcl"
+        self.pw = linux_password
 
     def run(self):
+        self.pw.redeem()
+
         # Install dependencies
         print(
             "PCL installation dependencies: libboost-all-dev (Boost), libflann-dev (FLANN), ligblew-dev (GLEW)")
@@ -43,6 +46,7 @@ class install_pcl:
             return
 
         # Build
+        self.pw.redeem()
         num_cpu_cores = multiprocessing.cpu_count()
         os.system("make -j" + str(num_cpu_cores-1))
         os.system("sudo make install -j" + str(num_cpu_cores-1))

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,22 @@ from scripts.third_party_clone.ceres.install_ceres_solver import install_ceres_s
 from scripts.third_party_clone.gtsam.install_gtsam import install_gtsam
 from scripts.third_party_clone.pcl.install_pcl import install_pcl
 
+class Password:
+    def __init__(self):
+        self.exist = False
+        self.data = ""
+
+    def fill(self, password):
+        self.exist = True
+        self.data = password
+
+    def redeem(self):
+        if self.data == "":
+            return
+
+        execString = "echo \"" + self.data + "\" | sudo -S echo \"Password activated\""
+        os.system(execString)
+
 
 def main():
     parser = argparse.ArgumentParser(description='Script for project setup')
@@ -53,6 +69,8 @@ def main():
                         help='Flag for installing OpenCV-python library.')
     parser.add_argument('--opencv_contrib_python', action='store_true',
                         help='Flag for installing opencv_contrib for python. `--opencv_python` flag needs to be set.')
+    parser.add_argument('--password', metavar='\b', type=str, default="",
+    help='Provide your Linux password to avoid manually typing in your password for every auto internal \'sudo\' command. If you are concerned about security, do not use this option.')
 
     args = parser.parse_args()
 
@@ -60,69 +78,92 @@ def main():
         parser.print_help()
         return
 
+    status_str = "Setup complete!: "
+
+    pw = Password()
+    if args.password != "":
+        pw.fill(args.password)
+
     if args.toolchain:
+        pw.redeem()
         os.system('chmod +x ./scripts/cpp_tool_chains/install_essentials.sh')
         os.system('chmod +x ./scripts/cpp_tool_chains/install_llvm_toolchain.sh')
         os.system('./scripts/cpp_tool_chains/install_essentials.sh')
         os.system('./scripts/cpp_tool_chains/install_llvm_toolchain.sh')
+        status_str += "--toolchain, "
 
     if args.utils:
-        installer = install_cpp_utils(args.d)
+        installer = install_cpp_utils(args.d, pw)
         installer.run()
+        status_str += "--utils, "
 
     if args.opencv != "":
+        pw.redeem()
         os.system(
             'chmod +x ./scripts/third_party_clone/opencv/install_opencv_deps.sh')
         os.system('./scripts/third_party_clone/opencv/install_opencv_deps.sh')
-        installer = install_opencv(args.d, args.opencv, args.opencv_contrib)
+        installer = install_opencv(args.d, args.opencv, args.opencv_contrib, pw)
         installer.run()
+        status_str += "--opencv, "
+
+        if args.opencv_contrib:
+            status_str += "--opencv_contrib, "
 
     if args.eigen != "":
-        installer = install_eigen(args.d, args.eigen)
+        installer = install_eigen(args.d, args.eigen, pw)
         installer.run()
+        status_str += "--eigen, "
 
     if args.pcl != "":
         if args.eigen == "":
-            installer = install_eigen(args.d, "3.3.9")
+            installer = install_eigen(args.d, "3.3.9", pw)
             installer.run()
 
-        installer = install_pcl(args.d, args.pcl)
+        installer = install_pcl(args.d, args.pcl, pw)
         installer.run()
+        status_str += "--pcl, "
 
     if args.ceres != "":
         if args.eigen == "":
-            installer = install_eigen(args.d, "3.3.9")
+            installer = install_eigen(args.d, "3.3.9", pw)
             installer.run()
 
-        installer = install_ceres_solver(args.d, args.ceres)
+        installer = install_ceres_solver(args.d, args.ceres, pw)
         installer.run()
+        status_str += "--ceres, "
 
     if args.gtsam != "":
-        installer = install_gtsam(args.d, args.gtsam)
+        installer = install_gtsam(args.d, args.gtsam, pw)
         installer.run()
+        status_str += "--gtsam, "
 
     if args.python3 or args.open3d or args.opencv_python:
+        pw.redeem()
+
         os.system('sudo apt install -y python3 python3-venv')
         shutil.rmtree('./python_venv', ignore_errors=True)
         os.system('> requirements.txt')
 
         if args.python3:
             os.system('cat ./scripts/python_packages/basic_python_packages.txt >> ./requirements.txt')
+            status_str += "--python3, "
 
         if args.open3d:
             os.system('cat ./scripts/python_packages/open3d.txt >> ./requirements.txt')
+            status_str += "--open3d, "
 
         if args.opencv_python:
             os.system('cat ./scripts/python_packages/opencv-python.txt >> ./requirements.txt')
+            status_str += "--opencv_python, "
 
             if args.opencv_contrib_python:
                 os.system('cat ./scripts/python_packages/opencv-contrib-python.txt >> ./requirements.txt')
-        
+                status_str += "--opencv_contrib_python, "
 
         os.system('chmod u+x ./scripts/python_packages/install_python_packages.sh')
         os.system('./scripts/python_packages/install_python_packages.sh')
 
-    print("Setup complete!")
+    print(status_str)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def main():
     parser.add_argument('--opencv_contrib_python', action='store_true',
                         help='Flag for installing opencv_contrib for python. `--opencv_python` flag needs to be set.')
     parser.add_argument('--password', metavar='\b', type=str, default="",
-    help='Provide your Linux password to avoid manually typing in your password for every auto internal \'sudo\' command. If you are concerned about security, do not use this option.')
+    help='Provide your Linux password to avoid manually typing in your password for every auto internal \'sudo\' command usage. This will leave traces of your password in your shell history - if you are concerned about security, do not use this option.')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
`setup.py`를 실행할 때 `--password`라는 optional argument를 사용해서 리눅스 비밀번호를 입력하면, `sudo ...` 커맨드를 사용할 때 마다 비밀번호를 넣어주지 않아도 되는 기능을 추가하였습니다.

`Password`라는 클래스를 만들어서 `redeem`이라는 멤버 함수를 호출하면서 sudo 권한을 풀어주는 방식으로 구현되어있습니다. 패스워드가 사용될 때 마다 'Password activated!'라는 문구가 뜹니다.

![image](https://user-images.githubusercontent.com/39010111/117888012-85b21a80-b2ec-11eb-9f13-4c38f533cbb0.png)


이 방식에 단점이 있을 수 있는데... Shell 기록에 비밀번호가 노출된다는 겁니다 :( 이 점에 대해서는 `setup.py`의 help에 명시해놨지만, 좀 더 좋은 방법을 생각해봐야 할 것 같습니다. 
![image](https://user-images.githubusercontent.com/39010111/117888447-0d982480-b2ed-11eb-886e-336031d856c4.png)
